### PR TITLE
Tweak dependencies

### DIFF
--- a/slug.opam
+++ b/slug.opam
@@ -14,10 +14,11 @@ depends: [
   "dune" {build}
   "opam-lock" {dev}
   "yojson" {dev}
-  "ppx_inline_test" {test}
+  "ppx_inline_test"
 
   "uunf"
   "uuseg"
+  "uutf"
   "re"
 ]
 synopsis: "Url safe slug generator"


### PR DESCRIPTION
- ppx_inline_test is required even when not testing, because the source files must be preprocessed:

    ```
    File "dune", line 6, characters 18-33:
    6 |  (preprocess (pps ppx_inline_test))
                          ^^^^^^^^^^^^^^^
    Error: Library "ppx_inline_test" not found.
    Hint: try:
      dune external-lib-deps --missing @@default
    ```

- `uuseg.string` requires `uutf` to be installed:

    ```
    File "dune", line 7, characters 31-43:
    7 |  (libraries yojson uunf.string uuseg.string re))
                                      ^^^^^^^^^^^^
    Error: Library "uuseg.string" in
    "/mnt/c/Users/\208\144\208\189\209\130\208\190\208\189/code/attic/ocaml-slug/_opam/lib/uuseg/string"
    is hidden (unsatisfied 'exist_if').
    Hint: try:
      dune external-lib-deps --missing @@default
    ```