### PR TITLE
Dune is not only a build-time dependency

### DIFF
--- a/slug.opam
+++ b/slug.opam
@@ -11,7 +11,7 @@ build: [
   [ "dune" "build" "-p" name "-j" jobs ]
 ]
 depends: [
-  "dune" {build}
+  "dune"
   "opam-lock" {dev}
   "yojson" {dev}
   "alcotest" {with-test}


### PR DESCRIPTION
I don't remember the details, but see https://github.com/ocaml/opam-repository/pull/14266.