### PR TITLE
Drop unnecessary fields from slug.opam

### DIFF
--- a/slug.opam
+++ b/slug.opam
@@ -1,11 +1,9 @@
 opam-version: "2.0"
-name: "slug"
 authors: "Khoa Nguyen"
 homepage: "https://github.com/thangngoc89/ocaml-slug"
 maintainer: "hi@khoanguyen.me"
 dev-repo: "git+ssh://git@github.com:thangngoc89/ocaml-slug.git"
 bug-reports: "https://github.com/thangngoc89/ocaml-slug/issues"
-version: "0.1"
 build: [
   [ "dune" "subst" ] {pinned}
   [ "dune" "build" "-p" name "-j" jobs ]


### PR DESCRIPTION
- `name` is taken by opam from the file's context.
- omitting `version` allows releasing without tweaking `slug.opam`.